### PR TITLE
Fixes a typo in PCSX2 saves path

### DIFF
--- a/functions/EmuScripts/emuDeckPCSX2QT.ps1
+++ b/functions/EmuScripts/emuDeckPCSX2QT.ps1
@@ -39,7 +39,7 @@ function PCSX2QT_setupSaves(){
 	setMSG "PCSX2 - Saves Links"
 	#memcards
 	$simLinkPath = "$emusPath\PCSX2-Qt\memcards"
-	$emuSavePath = "$emulationPat\saves\pcsx2\saves"
+	$emuSavePath = "$emulationPath\saves\pcsx2\saves"
 	createSaveLink $simLinkPath $emuSavePath
 
 	#States


### PR DESCRIPTION
Prevent [Drive]:\saves\pcsx2\saves being created & linked by creating in the appropriate folder