### PR TITLE
Fix bios symlink for Ryujinx

### DIFF
--- a/functions/EmuScripts/emuDeckRyujinx.ps1
+++ b/functions/EmuScripts/emuDeckRyujinx.ps1
@@ -53,10 +53,6 @@ function Ryujinx_setupSaves(){
 	$emuSavePath = "$emulationPath\saves\ryujinx\saveMeta"
 	createSaveLink $simLinkPath $emuSavePath
 
-	$simLinkPath = "$emusPath\Ryujinx\portable\system"
-	$emuSavePath = "$emulationPath\saves\ryujinx\system"
-	createSaveLink $simLinkPath $emuSavePath
-
 	#cloud_sync_save_hash "$savesPath\ryujinx"
 
 }


### PR DESCRIPTION
It took me some time to realize why my prod.keys were not being recognized by Ryujinx.

Then I found this:

![image](https://github.com/EmuDeck/emudeck-we/assets/29582865/d2368fa9-c20a-4c7d-a843-9dc11da0b605)

Which is wrong, it should be going to bios folder not saves.