### PR TITLE
Add Citra path for ES-DE

### DIFF
--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -15,6 +15,7 @@
 		<entry>%ESPATH%\Emulators\Citra\canary-mingw\citra-qt.exe</entry>
 		<entry>%ESPATH%\..\Emulators\Citra\nightly-mingw\citra-qt.exe</entry>
 		<entry>%ESPATH%\..\Emulators\Citra\canary-mingw\citra-qt.exe</entry>
+		<entry>%ESPATH%\Emulators\Citra\citra-qt.exe</entry>
 	</rule>
 </emulator>
 </ruleList>


### PR DESCRIPTION
Added path to the citra-qt.exe that was causing ES-DE to fail to launch games into Citra Standalone.

This path is for a legacy install of Citra installed by EmuDeck before the takedown.