### PR TITLE
Update es_find_rules.xml

### DIFF
--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -21,6 +21,7 @@
 <emulator name="LIME3DS">
 	<rule type="staticpath">
 		<entry>%ESPATH%\Emulators\lime3ds\lime3ds-gui.exe</entry>
+		<entry>%ESPATH%\Emulators\lime3ds\lime3ds.exe</entry>
 	</rule>
 </emulator>
 </ruleList>


### PR DESCRIPTION
Should fix the problem with ES-DE not detecting Lime3DS due to a recent name change to the executable.