### PR TITLE
Name correction in launcher

### DIFF
--- a/functions/createLauncher.ps1
+++ b/functions/createLauncher.ps1
@@ -9,9 +9,7 @@ function createLauncher($ps1) {
   $ShortcutPathPs1 = "$toolsPath\launchers\$ps1.ps1"
   Copy-Item -Path $SourceFilePath -Destination $ShortcutPathPs1 -Force -ErrorAction SilentlyContinue
 
-  $cultureInfo = [System.Globalization.CultureInfo]::CurrentCulture
-  $textInfo = $cultureInfo.TextInfo
-  $name = $textInfo.ToTitleCase($ps1)
+  $name = $ps1
 
   if ($name -like "*EmulationStationDE*") {
     $name = "EmulationStationDE"


### PR DESCRIPTION
I have corrected the block of code that converted the name of the emulators into capitalize, now they look exactly as we wrote it in the script