### PR TITLE
Fix paths in ES-DE's es_find_rules.xml

### DIFF
--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -30,23 +30,23 @@
 		<entry>%ESPATH%\..\Emulators\Citra\nightly-mingw\citra-qt.exe</entry>
 		<entry>%ESPATH%\..\Emulators\Citra\canary-mingw\citra-qt.exe</entry>
 		<entry>%ESPATH%\Emulators\Citra\citra-qt.exe</entry>
-		<entry>%ESPATH%\..Emulators\Citra\citra-qt.exe</entry>
+		<entry>%ESPATH%\..\Emulators\Citra\citra-qt.exe</entry>
 	</rule>
 </emulator>
 <emulator name="LIME3DS">
 	<rule type="staticpath">
 		<entry>%ESPATH%\Emulators\azahar\azahar-gui.exe</entry>
 		<entry>%ESPATH%\Emulators\azahar\azahar.exe</entry>
-		<entry>%ESPATH%\..Emulators\azahar\azahar-gui.exe</entry>
-		<entry>%ESPATH%\..Emulators\azahar\azahar.exe</entry>
+		<entry>%ESPATH%\..\Emulators\azahar\azahar-gui.exe</entry>
+		<entry>%ESPATH%\..\Emulators\azahar\azahar.exe</entry>
 	</rule>
 </emulator>
 <emulator name="AZAHAR">
 	<rule type="staticpath">
 		<entry>%ESPATH%\Emulators\azahar\azahar-gui.exe</entry>
 		<entry>%ESPATH%\Emulators\azahar\azahar.exe</entry>
-		<entry>%ESPATH%\..Emulators\azahar\azahar-gui.exe</entry>
-		<entry>%ESPATH%\..Emulators\azahar\azahar.exe</entry>
+		<entry>%ESPATH%\..\Emulators\azahar\azahar-gui.exe</entry>
+		<entry>%ESPATH%\..\Emulators\azahar\azahar.exe</entry>
 	</rule>
 </emulator>
 </ruleList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -42,7 +42,7 @@
 		<path>%ROMPATH%\switch</path>
 		<extension>.nca .NCA .nro .NRO .nso .NSO .nsp .NSP .xci .XCI</extension>
 		<command label="Yuzu (Standalone)">%EMULATOR_YUZU% -f -g %ROM%</command>
-		<command label="Citron (Standalone)">%EMULATOR_YUZU% -f -g %ROM%</command>
+		<command label="Citron (Standalone)">%EMULATOR_CITRON% -f -g %ROM%</command>
 		<command label="Ryujinx (Standalone)">%EMULATOR_RYUJINX% %ROM%</command>
 		<platform>switch</platform>
 		<theme>switch</theme>


### PR DESCRIPTION
It's looking for yuzu even if we select citron.