### PR TITLE
Cleaning customs conf following ES-DE update

### DIFF
--- a/configs/emulationstation/custom_systems/es_find_rules.xml
+++ b/configs/emulationstation/custom_systems/es_find_rules.xml
@@ -15,19 +15,4 @@
 		<entry>%ESPATH%\..\Emulators\citron\citron.exe</entry>
 	</rule>
 </emulator>
-<emulator name="SHADPS4">
-	<!-- PS4 emulator ShadPS4 -->
-	<rule type="staticpath">
-		<entry>%ESPATH%\Emulators\shadps4-qt\shadps4.exe</entry>
-		<entry>%ESPATH%\..\Emulators\shadps4-qt\shadps4.exe</entry>
-	</rule>
-</emulator>
-<emulator name="AZAHAR">
-	<rule type="staticpath">
-		<entry>%ESPATH%\Emulators\azahar\azahar-gui.exe</entry>
-		<entry>%ESPATH%\Emulators\azahar\azahar.exe</entry>
-		<entry>%ESPATH%\..\Emulators\azahar\azahar-gui.exe</entry>
-		<entry>%ESPATH%\..\Emulators\azahar\azahar.exe</entry>
-	</rule>
-</emulator>
 </ruleList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -1,41 +1,5 @@
 <?xml version="1.0"?>
 <systemList>
-    <system>
-        <name>ps3</name>
-        <fullname>Sony PlayStation 3</fullname>
-        <path>%ROMPATH%\ps3</path>
-        <extension>.ps3 .PS3</extension>
-        <command label="RPCS3 Directory (Standalone)">%EMULATOR_RPCS3% --no-gui %ROM%</command>
-        <platform>ps3</platform>
-        <theme>ps3</theme>
-    </system>
-	<system>
-		<name>ps3-shortcut</name>
-		<fullname>Sony PlayStation 3 - Shortcut Games</fullname>
-		<path>%ROMPATH%\ps3\shortcuts</path>
-		<extension>.lnk .LNK</extension>
-		<command label="RPCS3 Shortcut (Standalone)">%HIDEWINDOW% %ESCAPESPECIALS% %EMULATOR_OS-SHELL% /C %ROM%</command>
-		<platform>ps3</platform>
-		<theme>ps3</theme>
-	</system>
-	<system>
-		<name>ps4</name>
-		<fullname>Sony PlayStation 4</fullname>
-		<path>%ROMPATH%\ps4\shortcuts</path>
-		<extension>.lnk .LNK</extension>
-		<command label="ShadPS4 Shortcut (Standalone)">%ESCAPESPECIALS% %EMULATOR_OS-SHELL% /C %ROM%</command>
-		<platform>ps4</platform>
-		<theme>ps4</theme>
-	</system>
-	<!-- <system>
-		<name>ps4-pkg</name>
-		<fullname>Sony PlayStation 4</fullname>
-		<path>%ROMPATH%\ps4</path>
-		<extension>.ps4 .PS4</extension>
-		<command label="RPCS3 Directory (Standalone)">%EMULATOR_SHADPS4% --no-gui %ROM%</command>
-		<platform>ps4</platform>
-		<theme>ps4</theme>
-	</system> -->
 	<system>
 		<name>switch</name>
 		<fullname>Nintendo Switch</fullname>
@@ -43,19 +7,7 @@
 		<extension>.nca .NCA .nro .NRO .nso .NSO .nsp .NSP .xci .XCI</extension>
 		<command label="Yuzu (Standalone)">%EMULATOR_YUZU% -f -g %ROM%</command>
 		<command label="Citron (Standalone)">%EMULATOR_CITRON% -f -g %ROM%</command>
-		<command label="Ryujinx (Standalone)">%EMULATOR_RYUJINX% %ROM%</command>
 		<platform>switch</platform>
 		<theme>switch</theme>
-	</system>
-	<system>
-		<name>n3ds</name>
-		<fullname>Nintendo 3DS</fullname>
-		<path>%ROMPATH%\n3ds</path>
-		<extension>.3ds .3DS .3dsx .3DSX .app .APP .axf .AXF .cci .CCI .cxi .CXI .elf .ELF .7z .7Z .zip .ZIP</extension>
-		<command label="Citra">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%\citra_libretro.dll %ROM%</command>
-		<command label="Citra 2018">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%\citra2018_libretro.dll %ROM%</command>
-		<command label="Azahar (Standalone)">%EMULATOR_AZAHAR% %ROM%</command>
-		<platform>n3ds</platform>
-		<theme>n3ds</theme>
 	</system>
 </systemList>

--- a/configs/emulationstation/custom_systems/es_systems.xml
+++ b/configs/emulationstation/custom_systems/es_systems.xml
@@ -6,6 +6,7 @@
 		<path>%ROMPATH%\switch</path>
 		<extension>.nca .NCA .nro .NRO .nso .NSO .nsp .NSP .xci .XCI</extension>
 		<command label="Yuzu (Standalone)">%EMULATOR_YUZU% -f -g %ROM%</command>
+		<command label="Ryujinx (Standalone)">%EMULATOR_RYUJINX% %ROM%</command>
 		<command label="Citron (Standalone)">%EMULATOR_CITRON% -f -g %ROM%</command>
 		<platform>switch</platform>
 		<theme>switch</theme>

--- a/functions/EmuScripts/emuDeckCemu.ps1
+++ b/functions/EmuScripts/emuDeckCemu.ps1
@@ -38,7 +38,7 @@ function Cemu_setupSaves(){
 	setMSG "Cemu - Saves Links"
 	mkdir "$emusPath\cemu\mlc01\usr\" -ErrorAction SilentlyContinue
 	$simLinkPath = "$emusPath\cemu\mlc01\usr\save"
-	$emuSavePath = "$emulationPath/saves\Cemu\saves"
+	$emuSavePath = "$emulationPath\saves\Cemu\saves"
 	createSaveLink $simLinkPath $emuSavePath
 	#cloud_sync_save_hash "$savesPath\Cemu"
 }

--- a/functions/EmuScripts/emuDeckShadPS4.ps1
+++ b/functions/EmuScripts/emuDeckShadPS4.ps1
@@ -1,15 +1,15 @@
-$ShadPS4_configFile="$emusPath\ShadPS4-qt\user\config.toml"
+$ShadPS4_configFile="$emusPath\shadPS4\user\config.toml"
 
 function ShadPS4_install(){
 	setMSG "Downloading ShadPS4"
 	$url_ShadPS4 = "https://github.com/shadps4-emu/shadPS4/releases/download/v.0.4.0/shadps4-win64-qt-0.4.0.zip"
 	download $url_ShadPS4 "ShadPS4.zip"
-	moveFromTo "$temp/ShadPS4" "$emusPath\ShadPS4-qt"
+	moveFromTo "$temp/shadPS4" "$emusPath\shadPS4"
 	createLauncher "shadps4"
 }
 function ShadPS4_init(){
 	setMSG "ShadPS4 - Configuration"
-	$destination="$emusPath\ShadPS4-qt\user"
+	$destination="$emusPath\shadPS4\user"
 	mkdir $destination -ErrorAction SilentlyContinue
 	copyFromTo "$env:APPDATA\EmuDeck\backend\configs\ShadPS4" "$destination"
 	#ShadPS4_setResolution $ShadPS4Resolution
@@ -30,9 +30,9 @@ function ShadPS4_setResolution($resolution){
 
 function ShadPS4_setupSaves(){
 	setMSG "ShadPS4 - Saves Links"
-	mkdir "$emusPath\shadps4-qt\user"  -ErrorAction SilentlyContinue
-	mkdir "$emusPath\shadps4-qt\user\savedata"  -ErrorAction SilentlyContinue
-	$simLinkPath = "$emusPath\shadps4-qt\user\savedata"
+	mkdir "$emusPath\shadps4\user"  -ErrorAction SilentlyContinue
+	mkdir "$emusPath\shadps4\user\savedata"  -ErrorAction SilentlyContinue
+	$simLinkPath = "$emusPath\shadps4\user\savedata"
 	$emuSavePath = "$emulationPath\saves\shadps4\saves"
 	createSaveLink $simLinkPath $emuSavePath
 }
@@ -45,7 +45,7 @@ function ShadPS4_wipe(){
 	Write-Output "NYI"
 }
 function ShadPS4_uninstall(){
-	Remove-Item -path "$emusPath\ShadPS4-qt" -recurse -force
+	Remove-Item -path "$emusPath\shadPS4" -recurse -force
 	if($?){
 		Write-Output "true"
 	}
@@ -72,7 +72,7 @@ function ShadPS4_finalize(){
 	Write-Output "NYI"
 }
 function ShadPS4_IsInstalled(){
-	$test=Test-Path -Path "$emusPath\ShadPS4-qt\shadPS4.exe"
+	$test=Test-Path -Path "$emusPath\shadPS4\shadPS4.exe"
 	if($test){
 		Write-Output "true"
 	}else{


### PR DESCRIPTION
Proposing some cleaning in for ES-DE Scanning systems / roms:
-es_find_rules.xml
-es_systems.xml
Following the last update they added azahar, ryujinx, shadps4, rpsc3 shortcut . 
Shadps4 need to be in the same typo as ES-DE conf to show properly in the alternative emulators, so typo correction for : 
- emuDeckShadPS4.ps1

(for ryujinx entry):
I tried to see if we can remove ryujinx in custom as its already in the last update, but if i removed the line in es_systems.xml, ryujinx will not apear in the alternative emulators selection .

I tested to run the modified emuDeckShadPS4.ps1 in emudeck app + installing ES-DE .
In the newly named shadps4 i installed a game and created a shortcut do desktop and put in /emulation/roms/ps4
I went in ES-DE Folder change with my new custom entry and run es-de .
Then settings > alternative emulators > ps4 > shadp4(shortcut) slected . tried to run my shorcut and all good.

I tried to launch azahar game also no issue . I didnt try switch or ps3 yet . 

Please Before merging into Main . 
- It Will lead a lot of users to have trouble (forcing reinstalling or renaming their Shadps4) 
- Users who did not update ES-DE might be affected if they reset config of ES-DE , losing their custom conf . 
(this can be avoided by provinding as custom conf the same conf as ES-DE + our new entry as there is only one system we add in es_find_rules.xml / es_systems.xml) 

