### PR TITLE
[FIX] wrong extension for xml gamelist on startup

### DIFF
--- a/functions/appImageInit.ps1
+++ b/functions/appImageInit.ps1
@@ -146,7 +146,7 @@ function appImageInit(){
 		}else{
 			confirmDialog -TitleText "Citron ESDE fixed" -MessageText "There was an issue launching Citron from ESDE, we have just automatically fixed it. Now you can play your games using Citron from ESDE"
 			ESDE_init
-			Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\n3ds\gamelist.xml" -Destination "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue -Force
+			Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\switch\gamelist.xml" -Destination "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue -Force
 		}
 	}else{
 		mkdir "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue

--- a/functions/appImageInit.ps1
+++ b/functions/appImageInit.ps1
@@ -134,7 +134,7 @@ function appImageInit(){
 	if (Select-String -Path $xmlPath -Pattern "Citra") {
 		confirmDialog -TitleText "Azahar ESDE fixed" -MessageText "There was an issue launching Azahar from ESDE, we have just automatically fixed it. Now you can play 3DS Games using Azahar from ESDE"
 		ESDE_init
-		Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\n3ds\gamelist.xml" -Destination "$esdePath/ES-DE/gamelists/n3ds" -ErrorAction SilentlyContinue -Force
+		Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\n3ds\gamelist.xml" -Destination "$esdePath\ES-DE\gamelists\n3ds\" -ErrorAction SilentlyContinue -Force
 	}
 
 	#Citron ESDE fix
@@ -146,13 +146,13 @@ function appImageInit(){
 		}else{
 			confirmDialog -TitleText "Citron ESDE fixed" -MessageText "There was an issue launching Citron from ESDE, we have just automatically fixed it. Now you can play your games using Citron from ESDE"
 			ESDE_init
-			Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\switch\gamelist.xml" -Destination "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue -Force
+			Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\switch\gamelist.xml" -Destination "$esdePath\ES-DE\gamelists\switch\" -ErrorAction SilentlyContinue -Force
 		}
 	}else{
 		mkdir "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue
 		confirmDialog -TitleText "Citron ESDE fixed" -MessageText "There was an issue launching Citron from ESDE, we have just automatically fixed it. Now you can play your games using Citron from ESDE"
 		ESDE_init
-		Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\switch\gamelist.xml" -Destination "$esdePath/ES-DE/gamelists/switch" -ErrorAction SilentlyContinue -Force
+		Copy-Item "$env:APPDATA\EmuDeck\backend\configs\emulationstation\gamelists\switch\gamelist.xml" -Destination "$esdePath\ES-DE\gamelists\switch\" -ErrorAction SilentlyContinue -Force
 	}
 
 


### PR DESCRIPTION
/!\ I Cannot test my modification /!\

this file loads at the start up of emudeck so it regenerates everytime i launch emudeck . 

But to me there is typo issue with the path l137 l149 l155, 
and the choice of the emulator name for pulling the gamelist is wrong l149. 
https://github.com/dragoonDorise/EmuDeck/issues/1461

So im proposing those typos edits . but i repeat i cannot test it (so it might be not enough) 
Fell free read the issue before PR . as im not sure it will fix totally .