### PR TITLE
Fixed xenia launcher

### DIFF
--- a/configs/xenia/xenia-canary.config.toml
+++ b/configs/xenia/xenia-canary.config.toml
@@ -86,7 +86,7 @@ d3d12_tiled_shared_memory = true                  	# Enable tiled resources for 
 
 
 [Display]
-fullscreen = true                                	# Whether to launch the emulator in fullscreen.
+fullscreen = false                                	# Whether to launch the emulator in fullscreen.
 host_present_from_non_ui_thread = true            	# Allow the GPU emulation thread to present the guest output to the host surface directly instead of requesting the UI thread to do so through the host window system.
 internal_display_resolution = 8                   	# Allow game that support different resolutions to be rendered in specific resolution.   0=640x480
                                                   	#    1=640x576

--- a/tools/launchers/xenia.ps1
+++ b/tools/launchers/xenia.ps1
@@ -1,8 +1,20 @@
 $emulatorFile = "$env:APPDATA/emudeck/Emulators/xenia/xenia_canary.exe"
 $scriptFileName = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
 . "$env:USERPROFILE/AppData/Roaming/EmuDeck/backend/functions/allCloud.ps1"
-if($args){
-	$formattedArgs = $args | ForEach-Object { '"' + $_ + '"' }
+
+$wd = Split-Path -Parent $emulatorFile
+
+$global:PSDefaultParameterValues['Start-Process:WorkingDirectory'] = $wd
+
+$formattedArgs = ($args | ForEach-Object {
+  if ($_ -match '^\s*$') { $null }
+  elseif ($_ -match '^".*"$') { $_ }
+  elseif ($_ -match '\s') { '"' + $_ + '"' }
+  else { $_ }
+}) -join ' '
+
+if ($formattedArgs -and $formattedArgs -notmatch '\-\-fullscreen=') {
+  $formattedArgs = "$formattedArgs --fullscreen=true"
 }
 
-emulatorInit $scriptFileName $emulatorFile ($formattedArgs -join ' ')
+emulatorInit $scriptFileName $emulatorFile $formattedArgs


### PR DESCRIPTION
The xenia.ps1 file has been fixed because it did not start the emulator or the games correctly.