### PR TITLE
Melonds installation file fixed

### DIFF
--- a/functions/EmuScripts/emuDeckmelonDS.ps1
+++ b/functions/EmuScripts/emuDeckmelonDS.ps1
@@ -2,7 +2,7 @@ $melonD_configFile="$emusPath\melonDS\melonDS.ini"
 
 function melonDS_install(){
 	setMSG "Downloading melonDS"
-	$url_melonDS = getLatestReleaseURLGH "melonDS-emu/melonDS" "zip" "windows"
+	$url_melonDS = getLatestReleaseURLGH "melonDS-emu/melonDS" "zip" "windows" "aarch64"
 	download $url_melonDS "melonds.zip"
 	moveFromTo "$temp/melonDS" "$emusPath/melonDS"
 	Remove-Item -Recurse -Force melonds.zip -ErrorAction SilentlyContinue


### PR DESCRIPTION
The Melonds repository on GitHub had been updated and the wrong file was being downloaded, this has been fixed with a filter.