### PR TITLE
Cloudsync userprofile fix

### DIFF
--- a/functions/ToolScripts/emuDeckSaveSync.ps1
+++ b/functions/ToolScripts/emuDeckSaveSync.ps1
@@ -853,7 +853,7 @@ function cloud_sync_init($emulator){
 					"$emulator" | Set-Content $savesPath/.emulator -Encoding UTF8
 				}
 
-				Start-Process powershell.exe -ArgumentList "-ExecutionPolicy Bypass -File `"$env:USERPROFILE/AppData/Roaming/EmuDeck/backend/tools/cloudSync/cloud_sync_watcher_user.ps1`" $env:USERNAME"
+				Start-Process powershell.exe -ArgumentList "-ExecutionPolicy Bypass -File `"$env:USERPROFILE/AppData/Roaming/EmuDeck/backend/tools/cloudSync/cloud_sync_watcher_user.ps1`""
 
 				# & "$env:USERPROFILE/AppData/Roaming/EmuDeck/backend/wintools/nssm.exe" stop "CloudWatch"
 				# cls

--- a/tools/cloudSync/cloud_sync_watcher_user.ps1
+++ b/tools/cloudSync/cloud_sync_watcher_user.ps1
@@ -1,5 +1,4 @@
-$user="$args"
-$userPath = "C:\Users\$user"
+$userPath = $env:USERPROFILE
 $logPath = Join-Path -Path "$userPath" -ChildPath '\AppData\Roaming\EmuDeck\logs\cloudWatcher.log'
 $f1 = Join-Path -Path "$userPath" -ChildPath '\AppData\Roaming\EmuDeck\settings.ps1'
 $f2 = Join-Path -Path "$userPath" -ChildPath 'AppData\Roaming\EmuDeck\backend\functions\createLink.ps1'


### PR DESCRIPTION
Problem: Cloudsync was failing on my system because of an assumption that the user profile will always be "C:\Users\<USERNAME>" -- there are many cases where this assumption is not true in Windows. 

Fix: Utilize $env:USERPROFILE which is more accurate than cobbling together the userprofile path with "C:\Users\" and $env:USERNAME